### PR TITLE
CMake: allow larger cmake versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Check if cmake has the required version
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6.0 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 2.6.0...5.0.0 FATAL_ERROR)
 
 # Set project name
 PROJECT(serialtalk)


### PR DESCRIPTION
Fixes compatibility with CMake 4.0.0, which forces an explicit compatibility declaration in this way: https://gitlab.kitware.com/cmake/cmake/-/issues/26698 Does not break support for older versions which ignore this part (interpreted as sub-version).

Note: This will fix https://bugs.gentoo.org/953524 