### PR TITLE
Add github action CI tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,35 @@
+name: "Run tests"
+
+on:
+  push
+
+jobs:
+  test-build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Update apt repos
+      run: |
+        sudo apt-get -y update
+
+    - name: Install basics for compilation
+      run: |
+        sudo apt-get -y install build-essential
+
+    - name: Checkout repo
+      uses: actions/checkout@v3
+
+    - name: Compile and install
+      run: |
+        mkdir ~/build
+        mkdir ~/install
+        cd ~/build
+        cmake -DCMAKE_INSTALL_PREFIX:PATH=~/install ${GITHUB_WORKSPACE}/
+        make
+        make install
+
+    - name: Test execution
+      run: |
+        export PATH=${PATH}:~/install/bin
+        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:~/install/lib
+        serialtalk -h

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # serialtalk
 
-[![Build Status](https://travis-ci.org/BGO-OD/serialtalk.svg?branch=master)](https://travis-ci.org/BGO-OD/serialtalk)
-[![Issue Count](https://codeclimate.com/github/BGO-OD/serialtalk/badges/issue_count.svg)](https://codeclimate.com/github/BGO-OD/serialtalk)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/serialtalk.svg)](https://repology.org/project/serialtalk/versions)
+[![CI status](https://github.com/BGO-OD/serialtalk/actions/workflows/test-build.yml/badge.svg)](https://github.com/BGO-OD/serialtalk/actions/workflows/test-build.yml)
 
 [On OpenSuse build service](https://build.opensuse.org/package/show/home:JHannappel/serialtalk)
 
 [In official Gentoo portage tree](https://packages.gentoo.org/packages/dev-util/serialtalk)
 
-simple command-line tool to talk to serial devices
+A simple command-line tool to talk to serial devices.


### PR DESCRIPTION
This adds back some basic CI (after Travis is mostly dead) and updates the `README` accordingly. 
Also makes the `README` reference Repology for packaging status. 